### PR TITLE
fix: add electrum sync wait to numberpad tests

### DIFF
--- a/test/specs/numberpad.e2e.ts
+++ b/test/specs/numberpad.e2e.ts
@@ -32,11 +32,12 @@ describe('@numberpad - NumberPad', () => {
     electrum = await initElectrum();
     await reinstallApp();
     await completeOnboarding();
-    await receiveOnchainFunds(rpc, { sats: 10_000 });
+    await receiveOnchainFunds({ sats: 10_000 });
   });
 
   beforeEach(async () => {
     await launchFreshApp();
+    await electrum?.waitForSync();
   });
 
   describe('Modern denomination', () => {


### PR DESCRIPTION
Closes #102

## Summary
- Add `electrum?.waitForSync()` to `beforeEach` hook in numberpad tests
- Fix incorrect `receiveOnchainFunds(rpc, { sats: 10_000 })` call to use correct signature

## Root Cause Analysis
The numberpad Send tests (`@numberpad_2`, `@numberpad_4`) were **flaky** (pass sometimes, fail sometimes) because:

1. `launchFreshApp()` in `beforeEach` only sleeps 3 seconds after reactivating the app
2. The app needs to sync balance from Electrum after restart
3. 3 seconds is **sometimes enough** to sync (test passes), **sometimes not** (test fails → $0.00 balance → Continue button disabled)

All other working tests (send.e2e.ts, onchain.e2e.ts, backup.e2e.ts) call `electrum?.waitForSync()` in their `beforeEach` hook. This test was missing that call.

## Verification

Test run triggered via branch matching on bitkit-android:
https://github.com/synonymdev/bitkit-android/actions/runs/21151829121

🤖 Generated with [Claude Code](https://claude.com/claude-code)