### PR TITLE
feat: add homegate to docker-compose

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker/homegate"]
+	path = docker/homegate
+	url = https://github.com/pubky/homegate

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -161,6 +161,21 @@ services:
     ports:
       - '${LNURL_SERVER_PORT:-30001}:3000'
 
+  homegate:
+    profiles:
+      - homegate
+    build:
+      context: ./homegate
+    restart: unless-stopped
+    environment:
+      HG_HOMESERVER_ADMIN_API_URL: "${HG_HOMESERVER_ADMIN_API_URL:-https://admin.homeserver.staging.pubky.app}"
+      HG_HOMESERVER_ADMIN_PASSWORD: "${HG_HOMESERVER_ADMIN_PASSWORD:-test}"
+      HG_HOMESERVER_PUBKY: "${HG_HOMESERVER_PUBKY:-ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy}"
+      HG_MAX_IP_VERIFICATIONS_PER_WEEK: 9999
+      HG_MAX_IP_VERIFICATIONS_PER_YEAR: 9999
+    ports:
+      - '18080:8080'
+
 volumes:
   bitcoin_home:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -174,11 +174,6 @@ services:
       POSTGRES_DB: "${POSTGRES_DB:-homegate}"
     ports:
       - 5432:5432
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
 
   homegate:
     container_name: homegate
@@ -200,6 +195,7 @@ services:
       HG_PRELUDE_API_KEY: "${HG_PRELUDE_API_KEY:-}"
       HG_MAX_IP_VERIFICATIONS_PER_WEEK: 9999
       HG_MAX_IP_VERIFICATIONS_PER_YEAR: 9999
+      HG_PHOENIXD_API_URL: "${HG_PHOENIXD_API_URL:-http://127.0.0.1:9700}"
     ports:
       - '18080:8080'
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -161,16 +161,41 @@ services:
     ports:
       - '${LNURL_SERVER_PORT:-30001}:3000'
 
+
+  postgres:
+    container_name: postgres
+    profiles:
+      - homegate
+    image: postgres:17-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:-test}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-test}"
+      POSTGRES_DB: "${POSTGRES_DB:-homegate}"
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   homegate:
+    container_name: homegate
     profiles:
       - homegate
     build:
       context: ./homegate
     restart: unless-stopped
     environment:
+      HG_DATABASE_URL: "postgres://${POSTGRES_USER:-test}:${POSTGRES_PASSWORD:-test}@postgres:5432/${POSTGRES_DB:-homegate}"
       HG_HOMESERVER_ADMIN_API_URL: "${HG_HOMESERVER_ADMIN_API_URL:-https://admin.homeserver.staging.pubky.app}"
       HG_HOMESERVER_ADMIN_PASSWORD: "${HG_HOMESERVER_ADMIN_PASSWORD:-test}"
       HG_HOMESERVER_PUBKY: "${HG_HOMESERVER_PUBKY:-ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy}"
+      HG_LN_VERIFICATION_ENABLED: "${HG_LN_VERIFICATION_ENABLED:-false}"
+      HG_IP_VERIFICATION_ENABLED: "${HG_IP_VERIFICATION_ENABLED:-true}"
+      HG_SMS_VERIFICATION_ENABLED: "${HG_SMS_VERIFICATION_ENABLED:-false}"
+      HG_PRELUDE_API_KEY: "${HG_PRELUDE_API_KEY:-}"
       HG_MAX_IP_VERIFICATIONS_PER_WEEK: 9999
       HG_MAX_IP_VERIFICATIONS_PER_YEAR: 9999
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -197,7 +197,7 @@ services:
       HG_MAX_IP_VERIFICATIONS_PER_YEAR: 9999
       HG_PHOENIXD_API_URL: "${HG_PHOENIXD_API_URL:-http://127.0.0.1:9700}"
     ports:
-      - '18080:8080'
+      - '6288:8080'
 
 volumes:
   bitcoin_home:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -187,6 +187,8 @@ services:
     build:
       context: ./homegate
     restart: unless-stopped
+    depends_on:
+      - postgres
     environment:
       HG_DATABASE_URL: "postgres://${POSTGRES_USER:-test}:${POSTGRES_PASSWORD:-test}@postgres:5432/${POSTGRES_DB:-homegate}"
       HG_HOMESERVER_ADMIN_API_URL: "${HG_HOMESERVER_ADMIN_API_URL:-https://admin.homeserver.staging.pubky.app}"


### PR DESCRIPTION
the homegate is added ad submodule, currently pointing to `ip_verification` branch