### PR TITLE
test: paykit stabilization

### DIFF
--- a/test/helpers/profile.ts
+++ b/test/helpers/profile.ts
@@ -151,10 +151,12 @@ export async function addContact({
   pubky,
   save = true,
   firstContact = false,
+  waitToastToDisappear: waitToDisappear = driver.isIOS,
 }: {
   pubky: string;
   save?: boolean;
   firstContact?: boolean;
+  waitToastToDisappear?: boolean;
 }): Promise<void> {
   await openContacts();
   await sleep(500);
@@ -184,7 +186,7 @@ export async function addContact({
   await tap('AddContactAdd');
   await elementById('AddContactSave').waitForDisplayed();
   await tap('AddContactSave');
-  await waitForToast('ContactSavedToast', { waitToDisappear: driver.isIOS });
+  await waitForToast('ContactSavedToast', { waitToDisappear });
   await elementById('ContactsAddButton').waitForDisplayed();
 }
 
@@ -213,11 +215,10 @@ export async function verifyAddContactRoute(
   }
 
   await elementById('AddContactSave').waitForDisplayed();
-  await expect(
-    await elementById('AddContactPay')
-      .isDisplayed()
-      .catch(() => false)
-  ).toBe(ableToPay);
+  await elementById('AddContactPay').waitForDisplayed({
+    reverse: !ableToPay,
+    timeoutMsg: `add contact ${publicKey}: expected AddContactPay ${ableToPay ? 'visible' : 'hidden'} (fixture ableToPay=${ableToPay})`,
+  });
 }
 
 export async function discardAddContactRoute() {

--- a/test/specs/paykit.e2e.ts
+++ b/test/specs/paykit.e2e.ts
@@ -35,6 +35,7 @@ async function switchToOnchainIfNeeded() {
 }
 
 async function payCurrentContactOnchain(amountSats: number) {
+  await sleep(1000);
   await elementById('ContactPay').waitForDisplayed();
   await tap('ContactPay');
   await switchToOnchainIfNeeded();
@@ -88,7 +89,11 @@ describe('@pubky @paykit - Public payments', () => {
       });
       await discardAddContactRoute();
 
-      await addContact({ pubky: savedPaykitContact.pubky, firstContact: true });
+      await addContact({
+        pubky: savedPaykitContact.pubky,
+        firstContact: true,
+        waitToastToDisappear: true,
+      });
       await verifyContactRowDisplayed(savedPaykitContact.pubky);
       await tap(`Contact_${savedPaykitContact.pubky}`);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test helpers/spec timing and assertions, with no production logic impact; main risk is altering shared helper defaults that could affect other E2E tests’ expectations.
> 
> **Overview**
> Improves E2E stability around adding contacts and paying via Paykit.
> 
> `addContact` now accepts `waitToastToDisappear` (defaulting to iOS behavior) and the Paykit test opts into waiting for the save toast to fully clear. `verifyAddContactRoute` replaces a boolean `isDisplayed` check with a `waitForDisplayed({ reverse })` assertion for `AddContactPay` (with a clearer timeout message), and the pay flow adds an extra pre-click delay before `ContactPay` to reduce flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba0f26dd4c2538e9907845e99680f55be8c4803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->