### PR TITLE
ci: save diagnostics on pass when requested

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -362,7 +362,7 @@ export const config: WebdriverIO.Config = {
   },
 
   afterTest: async function (test, _context, { error }) {
-    if (!error) return; // Skip artifacts if test passed
+    const saveDiagnostics = Boolean(error) || process.env.SAVE_DIAGNOSTICS === 'true';
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const testNameRaw = `${test.parent || 'unknown'}_${test.title}`;
@@ -373,21 +373,24 @@ export const config: WebdriverIO.Config = {
     } else {
       testDir = path.join(__dirname, 'artifacts', testName);
     }
-    // Ensure per-test directory exists
-    fs.mkdirSync(testDir, { recursive: true });
 
-    // Save screenshot
-    const screenshotPath = path.join(testDir, `${testName}-${timestamp}.png`);
-    const screenshot = await driver.takeScreenshot();
-    fs.writeFileSync(screenshotPath, screenshot, 'base64');
-    console.log(`📸 Saved screenshot: ${screenshotPath}`);
+    if (saveDiagnostics) {
+      fs.mkdirSync(testDir, { recursive: true });
 
-    // Save video if recording was enabled
+      const screenshotPath = path.join(testDir, `${testName}-${timestamp}.png`);
+      const screenshot = await driver.takeScreenshot();
+      fs.writeFileSync(screenshotPath, screenshot, 'base64');
+      console.log(`📸 Saved screenshot: ${screenshotPath}`);
+    }
+
     if (process.env.RECORD_VIDEO === 'true') {
       const videoBase64 = await driver.stopRecordingScreen();
-      const videoPath = path.join(testDir, `${testName}-${timestamp}.mp4`);
-      fs.writeFileSync(videoPath, videoBase64, 'base64');
-      console.log(`🎥 Saved test video: ${videoPath}`);
+      if (saveDiagnostics) {
+        fs.mkdirSync(testDir, { recursive: true });
+        const videoPath = path.join(testDir, `${testName}-${timestamp}.mp4`);
+        fs.writeFileSync(videoPath, videoBase64, 'base64');
+        console.log(`🎥 Saved test video: ${videoPath}`);
+      }
     }
   },
 };


### PR DESCRIPTION
## Summary
- Add `SAVE_DIAGNOSTICS` env flag to persist screenshot and video on passing tests (not only failures).
- Always stop screen recording when `RECORD_VIDEO=true`, even on pass, so multi-test runs do not leave recording active.

## Why
Mainnet nightly wants diagnostics from successful runs for comparison (e.g. channel health baselines). Default behavior is unchanged when `SAVE_DIAGNOSTICS` is unset (android/ios PR CI).

## Test plan
- [ ] Merge and tag for nightly workflow
- [ ] Verify android/ios E2E still upload failure artifacts only (no `SAVE_DIAGNOSTICS` in app workflows)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to WebdriverIO test hooks and only affects artifact collection; main impact is potentially increased CI storage/time when `SAVE_DIAGNOSTICS=true`.
> 
> **Overview**
> Adds an opt-in `SAVE_DIAGNOSTICS` flag so the `afterTest` hook can persist screenshots and recorded videos even when tests pass, instead of only on failures.
> 
> When `RECORD_VIDEO=true`, the run now **always** stops screen recording after each test, and only writes the `.mp4` to disk when diagnostics are being saved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6245920440eaf2caba00ee4a65d1e9afac3cb2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->