### PR TITLE
test: handle paykit ui switch

### DIFF
--- a/test/helpers/actions.ts
+++ b/test/helpers/actions.ts
@@ -1166,6 +1166,8 @@ export type ToastId =
   | 'ExpiredLightningToast'
   | 'DevModeEnabledToast'
   | 'DevModeDisabledToast'
+  | 'PaykitUiEnabledToast'
+  | 'PaykitUiDisabledToast'
   | 'InsufficientSpendingToast'
   | 'InsufficientSavingsToast'
   | 'ProfilePubkyCopiedToast'

--- a/test/helpers/navigation.ts
+++ b/test/helpers/navigation.ts
@@ -26,6 +26,16 @@ export async function openSupport() {
 }
 
 /**
+ * Opens Dev Settings from the Advanced settings tab.
+ */
+export async function openDevSettings() {
+  await openSettings('advanced');
+  await elementById('DevSettings').waitForDisplayed();
+  await tap('DevSettings');
+  await sleep(500);
+}
+
+/**
  * Opens the Contacts entry from the drawer menu.
  */
 export async function openContacts() {

--- a/test/helpers/paykit.ts
+++ b/test/helpers/paykit.ts
@@ -1,0 +1,56 @@
+import { elementById, elementByText, sleep, swipeFullScreen, tap, waitForToast } from './actions';
+import { doNavigationClose, openDevSettings } from './navigation';
+
+const PAYKIT_UI_TOGGLE_ID = 'PaykitUiToggle';
+
+async function scrollToPaykitToggle() {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (await elementById(PAYKIT_UI_TOGGLE_ID).isDisplayed().catch(() => false)) {
+      return;
+    }
+    await swipeFullScreen('up');
+    await sleep(300);
+  }
+  await elementById(PAYKIT_UI_TOGGLE_ID).waitForDisplayed();
+}
+
+async function tapPaykitUiToggle() {
+  await scrollToPaykitToggle();
+  await tap(PAYKIT_UI_TOGGLE_ID);
+}
+
+async function confirmPaykitUiEnableDialogIfPresent() {
+  const enableButton = elementByText('Enable', 'exact');
+  if (await enableButton.isDisplayed().catch(() => false)) {
+    await enableButton.click();
+    await sleep(500);
+  }
+}
+
+async function leaveDevSettings() {
+  await tap('NavigationBack');
+  await doNavigationClose();
+}
+
+export async function enablePaykitUi() {
+  await openDevSettings();
+  await tapPaykitUiToggle();
+  await confirmPaykitUiEnableDialogIfPresent();
+  await waitForToast('PaykitUiEnabledToast', { waitToDisappear: driver.isIOS });
+  await leaveDevSettings();
+}
+
+export async function disablePaykitUi() {
+  await openDevSettings();
+  await tapPaykitUiToggle();
+  await waitForToast('PaykitUiDisabledToast', { waitToDisappear: driver.isIOS });
+  await leaveDevSettings();
+}
+
+export async function setPaykitUiEnabled(enabled: boolean) {
+  if (enabled) {
+    await enablePaykitUi();
+  } else {
+    await disablePaykitUi();
+  }
+}

--- a/test/specs/paykit.e2e.ts
+++ b/test/specs/paykit.e2e.ts
@@ -12,6 +12,7 @@ import {
 } from '../helpers/actions';
 import { STAGING_PAYKIT_CONTACTS } from '../helpers/fixtures';
 import { doNavigationClose, openContacts } from '../helpers/navigation';
+import { enablePaykitUi } from '../helpers/paykit';
 import {
   addContact,
   cleanupProfile,
@@ -60,6 +61,7 @@ describe('@pubky @paykit - Public payments', () => {
   beforeEach(async () => {
     await reinstallApp();
     await completeOnboarding();
+    await enablePaykitUi();
   });
 
   ciIt('@paykit_1 - Can pay saved contact via public on-chain endpoint', async () => {

--- a/test/specs/pubky-profile.e2e.ts
+++ b/test/specs/pubky-profile.e2e.ts
@@ -14,6 +14,7 @@ import {
 } from '../helpers/actions';
 import { STAGING_TEST_CONTACTS } from '../helpers/fixtures';
 import { openContacts, openProfile } from '../helpers/navigation';
+import { enablePaykitUi } from '../helpers/paykit';
 import {
   addContact,
   ADD_CONTACT_INVALID_KEY_MESSAGE_SNIPPET,
@@ -48,6 +49,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
   beforeEach(async () => {
     await reinstallApp();
     await completeOnboarding();
+    await enablePaykitUi();
   });
 
   // Section A: with no profile, every entry point must funnel into the choice screen.
@@ -251,6 +253,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
           await reinstallApp();
           currentWallet = null;
           await completeOnboarding();
+          await enablePaykitUi();
           await createProfile({ name: 'Bob Wallet B' });
           currentWallet = 'B';
 

--- a/test/specs/pubky-profile.e2e.ts
+++ b/test/specs/pubky-profile.e2e.ts
@@ -124,7 +124,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
           const seed = await getSeed();
           await waitForBackup();
           await restoreWallet(seed);
-          if (driver.isIOS) await enablePaykitUi();
+          await enablePaykitUi();
           await verifyMyProfileDetails(details);
           const pubkyAfterRestore = await readPubkyFromProfileCopy();
           await expect(pubkyAfterRestore).toBe(pubky.trim());
@@ -276,7 +276,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
 
           // Restore wallet A and verify wallet A profile is unchanged by wallet B contact edits.
           await restoreWallet(seedA);
-          if (driver.isIOS) await enablePaykitUi();
+          await enablePaykitUi();
           currentWallet = 'A';
           await verifyMyProfileDetails(detailsA);
         } finally {
@@ -287,7 +287,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
           if (seedA !== undefined && currentWallet !== 'A') {
             try {
               await restoreWallet(seedA);
-              if (driver.isIOS) await enablePaykitUi();
+              await enablePaykitUi();
               await cleanupProfile('@pubky_profile_4 wallet A');
             } catch (error) {
               console.warn('Could not restore and cleanup wallet A profile:', error);

--- a/test/specs/pubky-profile.e2e.ts
+++ b/test/specs/pubky-profile.e2e.ts
@@ -124,6 +124,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
           const seed = await getSeed();
           await waitForBackup();
           await restoreWallet(seed);
+          if (driver.isIOS) await enablePaykitUi();
           await verifyMyProfileDetails(details);
           const pubkyAfterRestore = await readPubkyFromProfileCopy();
           await expect(pubkyAfterRestore).toBe(pubky.trim());
@@ -275,6 +276,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
 
           // Restore wallet A and verify wallet A profile is unchanged by wallet B contact edits.
           await restoreWallet(seedA);
+          if (driver.isIOS) await enablePaykitUi();
           currentWallet = 'A';
           await verifyMyProfileDetails(detailsA);
         } finally {
@@ -285,6 +287,7 @@ describe('@pubky @pubky_profile - Pubky profile', () => {
           if (seedA !== undefined && currentWallet !== 'A') {
             try {
               await restoreWallet(seedA);
+              if (driver.isIOS) await enablePaykitUi();
               await cleanupProfile('@pubky_profile_4 wallet A');
             } catch (error) {
               console.warn('Could not restore and cleanup wallet A profile:', error);


### PR DESCRIPTION
 - https://github.com/synonymdev/bitkit-android/pull/957
 - https://github.com/synonymdev/bitkit-ios/pull/560

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk test-only changes that mainly adjust E2E setup/navigation; primary risk is increased flakiness if the Paykit toggle/toasts or dev-settings UI changes.
> 
> **Overview**
> Ensures Paykit-related E2E coverage runs with the Paykit UI feature enabled by adding a `test/helpers/paykit.ts` helper that navigates to Dev Settings, scrolls to/toggles `PaykitUiToggle`, handles the optional enable confirmation dialog, and waits for new `PaykitUiEnabledToast`/`PaykitUiDisabledToast`.
> 
> Updates navigation helpers with `openDevSettings()` and modifies `paykit.e2e.ts` and `pubky-profile.e2e.ts` to call `enablePaykitUi()` during `beforeEach` (and after reinstall mid-test), making tests resilient to the UI being off by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9378c5cae7816e1157a7a3c954a92f249991a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->