### PR TITLE
chore: add lightning link page

### DIFF
--- a/.github/workflows/deploy-ln-invoice-link.yml
+++ b/.github/workflows/deploy-ln-invoice-link.yml
@@ -1,0 +1,38 @@
+name: Deploy Lightning invoice link test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tools/ln-invoice-link/**
+      - .github/workflows/deploy-ln-invoice-link.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: tools/ln-invoice-link
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ docker/                 # docker compose regtest based backend for Bitkit wallet
 test/
   ├── specs/            # Test suites (e.g., onboarding.e2e.ts)
   ├── helpers/          # Test helpers: selectors, setup, actions
+tools/                  # QA utilities and small manual test tools
 ```
 
 > ℹ️ Screenshots and (optionally) videos of **failed tests** will be saved to `artifacts/`. To enable video recording, set the `RECORD_VIDEO=true` environment variable.

--- a/tools/ln-invoice-link/README.md
+++ b/tools/ln-invoice-link/README.md
@@ -1,0 +1,20 @@
+# Lightning invoice link test
+
+Static Safari test page for opening BOLT11 invoices through the `lightning:` URL scheme.
+
+## Usage
+
+1. Open the published GitHub Pages URL.
+2. Paste a BOLT11 invoice.
+3. Tap **Open lightning link** in Safari.
+
+The page accepts raw invoices such as `lnbcrt...`, `lntb...`, or `lnbc...`. It also accepts values already prefixed with `lightning:`.
+
+## Local preview
+
+```bash
+cd tools/ln-invoice-link
+python3 -m http.server 8080
+```
+
+Open `http://localhost:8080` on the simulator, or `http://<mac-lan-ip>:8080` on a physical iPhone connected to the same network.

--- a/tools/ln-invoice-link/index.html
+++ b/tools/ln-invoice-link/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bitkit Lightning Link Test</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.4;
+    }
+
+    body {
+      box-sizing: border-box;
+      margin: 0 auto;
+      max-width: 720px;
+      padding: 24px;
+    }
+
+    textarea {
+      box-sizing: border-box;
+      width: 100%;
+      min-height: 160px;
+      padding: 12px;
+      border-radius: 10px;
+      font: 14px ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    a {
+      display: inline-block;
+      margin-top: 16px;
+      padding: 12px 16px;
+      border-radius: 999px;
+      background: #0a84ff;
+      color: #fff;
+      font: inherit;
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    code {
+      word-break: break-all;
+    }
+
+    .muted {
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <h1>Bitkit Lightning Link Test</h1>
+  <p>Paste a BOLT11 invoice below, then open the generated link in Safari.</p>
+
+  <label for="invoice">Invoice</label>
+  <textarea id="invoice" spellcheck="false" placeholder="lnbcrt..., lntb..., or lnbc..."></textarea>
+
+  <p>
+    <a id="pay-link" href="#">Open lightning link</a>
+  </p>
+
+  <p class="muted">Generated URL:</p>
+  <code id="generated">Paste an invoice first.</code>
+
+  <script>
+    const invoiceInput = document.getElementById("invoice");
+    const payLink = document.getElementById("pay-link");
+    const generated = document.getElementById("generated");
+
+    function normalizeInvoice(value) {
+      return value.trim().replace(/^lightning:/i, "");
+    }
+
+    function updateLink() {
+      const invoice = normalizeInvoice(invoiceInput.value);
+
+      if (!invoice) {
+        payLink.href = "#";
+        generated.textContent = "Paste an invoice first.";
+        return;
+      }
+
+      const url = `lightning:${invoice}`;
+      payLink.href = url;
+      generated.textContent = url;
+    }
+
+    invoiceInput.addEventListener("input", updateLink);
+    updateLink();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a small static QA page for opening pasted BOLT11 invoices via the `lightning:` URL scheme in Safari.
- Add a GitHub Pages workflow that publishes `tools/ln-invoice-link` from `main`.
- Document the tool and add `tools/` to the repo directory overview.

## Test plan
- Checked workflow diagnostics with Cursor lints.
- Ran `git diff --cached --check`.
- Not run: E2E tests, static HTML/docs/workflow-only change.


Made with [Cursor](https://cursor.com)