### PR TITLE
Require positive value for PROBE_READINESS_TIMEOUT_MS

### DIFF
--- a/test/helpers/probe.ts
+++ b/test/helpers/probe.ts
@@ -276,7 +276,7 @@ type WaitForProbeReadinessOptions = {
 export async function waitForProbeReadiness({
   logPrefix,
 }: WaitForProbeReadinessOptions): Promise<ProbeReadiness> {
-  const timeoutMs = parseNonNegativeIntEnv('PROBE_READINESS_TIMEOUT_MS') ?? DEFAULT_READINESS_TIMEOUT_MS;
+  const timeoutMs = parsePositiveIntEnv('PROBE_READINESS_TIMEOUT_MS') ?? DEFAULT_READINESS_TIMEOUT_MS;
   const pollMs = parsePositiveIntEnv('PROBE_READINESS_POLL_MS') ?? DEFAULT_READINESS_POLL_MS;
   const minGraphChannels =
     parseNonNegativeIntEnv('PROBE_MIN_GRAPH_CHANNELS') ?? DEFAULT_MIN_GRAPH_CHANNELS;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change `waitForProbeReadiness` to parse `PROBE_READINESS_TIMEOUT_MS` with `parsePositiveIntEnv`
- prevent `PROBE_READINESS_TIMEOUT_MS=0` from bypassing the default and skipping all poll attempts
- align readiness timeout parsing with existing positive-only timeout/poll env parsing

## Testing
- not run (local JS tooling dependencies are not installed in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43e60c0c-dfb1-4df8-9c32-48e00edfef9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43e60c0c-dfb1-4df8-9c32-48e00edfef9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

