### PR TITLE
test: recover from android ANR dialog on restore

### DIFF
--- a/test/helpers/actions.ts
+++ b/test/helpers/actions.ts
@@ -396,6 +396,53 @@ export async function multiTap(testId: string, count: number) {
 }
 
 /**
+ * Android emulators under memory pressure can trigger a system "<app> isn't responding"
+ * (ANR) dialog — often for the launcher — that steals window focus and hides the app
+ * under test from UiAutomator. Dismiss it via "Wait" (falling back to "Close app").
+ * No-op on iOS and when no dialog is present.
+ */
+export async function dismissAndroidAnrDialog(): Promise<boolean> {
+  if (!driver.isAndroid) {
+    return false;
+  }
+
+  for (const resourceId of ['android:id/aerr_wait', 'android:id/aerr_close']) {
+    try {
+      const button = $(`android=new UiSelector().resourceId("${resourceId}")`);
+      if (await button.isExisting()) {
+        console.info(`→ Dismissing Android ANR dialog via ${resourceId}...`);
+        await button.click();
+        await sleep(1000);
+        return true;
+      }
+    } catch {
+      // Dialog not present or not queryable; try the next button.
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Waits for an element by id, recovering once from a system ANR dialog that may be
+ * stealing focus (common on loaded CI emulators during onboarding).
+ */
+export async function waitForDisplayedWithAnrRecovery(
+  testId: string,
+  { timeout = 60_000 }: { timeout?: number } = {}
+): Promise<void> {
+  try {
+    await elementById(testId).waitForDisplayed({ timeout });
+  } catch (error) {
+    const dismissed = await dismissAndroidAnrDialog();
+    if (!dismissed) {
+      throw error;
+    }
+    await elementById(testId).waitForDisplayed({ timeout });
+  }
+}
+
+/**
  * Reads the device clipboard as UTF-8 text (Appium returns base64-encoded content).
  */
 export async function getClipboardPlaintext(): Promise<string> {
@@ -690,7 +737,8 @@ export async function restoreWallet(
   }
 
   // Terms of service
-  await elementById('Continue').waitForDisplayed({ timeout: 60_000 });
+  await dismissAndroidAnrDialog();
+  await waitForDisplayedWithAnrRecovery('Continue', { timeout: 60_000 });
   await sleep(1000); // Wait for the app to settle
   await tap('Continue');
   await sleep(500);


### PR DESCRIPTION
Part of synonymdev/bitkit-nightly#17

Makes the Android test harness resilient to system "<app> isn't responding" (ANR) dialogs that can appear on loaded CI emulators — typically for the launcher — and steal window focus, hiding the app under test from UiAutomator.

In nightly probe run [26730571593](https://github.com/synonymdev/bitkit-nightly/actions/runs/26730571593) both attempts failed at onboarding with `element resourceId("Continue") still not displayed after 60000ms`. logcat showed `ANR in com.android.launcher3 (QuickstepLauncher): Input dispatching timed out (Application does not have a focused window)` — the launcher ANR dialog had grabbed focus, so the Continue button was unreachable even though it was on screen.

## Summary
- Adds `dismissAndroidAnrDialog()` which taps the system ANR dialog's **Wait** (falling back to **Close app**) button; no-op on iOS and when no dialog is present.
- Adds `waitForDisplayedWithAnrRecovery()` which retries an element wait once after dismissing an ANR dialog.
- Uses both at the onboarding entry point in `restoreWallet`, the step that was getting blocked.

This is the harness-side companion to the emulator memory/animation hardening in synonymdev/bitkit-nightly (which reduces how often the ANR happens in the first place).

## Test plan
- [x] Run any restore-based spec (e.g. `@probe_mainnet`): onboarding proceeds; if a launcher ANR dialog appears it is dismissed and the run continues.
- [x] Confirm no behavior change on iOS (helper is a no-op there).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness only; iOS is unchanged and production app code is untouched.
> 
> **Overview**
> Adds **Android-only** E2E recovery for system **ANR** dialogs (e.g. launcher “isn’t responding”) that steal focus on loaded CI emulators and make UiAutomator miss in-app elements.
> 
> New helpers **`dismissAndroidAnrDialog`** (tap **Wait**, else **Close app**; no-op on iOS) and **`waitForDisplayedWithAnrRecovery`** (one retry after dismissal). **`restoreWallet`** now proactively dismisses ANR before waiting on onboarding **`Continue`**, replacing a plain `waitForDisplayed` that was timing out in nightly runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d48c81cf80c1ddb901e8a73442554679ff13cc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->