### PR TITLE
fix: allow taproot change in multi_address_4 savings check

### DIFF
--- a/test/specs/multiaddress.e2e.ts
+++ b/test/specs/multiaddress.e2e.ts
@@ -285,9 +285,8 @@ describe('@multi_address - Multi address', () => {
       }
       await checkChannelStatus({ size: formatSats(channelSize) });
 
-      // savings has all legacy funds
-      const savingsBalance = await getSavingsBalance();
-      await expect(savingsBalance).toEqual(satsPerAddressType);
+      // savings includes legacy; max channel funding may leave small taproot change
+      await expectSavingsBalance(satsPerAddressType, { condition: 'gte' });
 
       await openSettings('advanced');
       await sleep(1000);


### PR DESCRIPTION
## Summary
- Fixes flaky `@multi_address_4` failures where savings balance was asserted as exactly 25,000 sats after max channel funding.
- Savings shows total on-chain balance, which can include small taproot change UTXOs left from channel funding (~1–2k sats).
- Replaces strict equality with `expectSavingsBalance(..., { condition: 'gte' })`; legacy address viewer assertion still verifies legacy funds are untouched.

## Context
CI on bitkit-android PR #978 failed only on `multi_address_local` shard, attempts 2–3:
- Expected savings **25,000**, got **26,220** / **26,758** (legacy 25k + change).

## Test plan
- [ ] Run `npm run e2e:android -- --spec ./test/specs/multiaddress.e2e.ts --mochaOpts.grep "@multi_address_4"`
- [ ] Confirm `@multi_address_1`–`@multi_address_3` still pass in the same spec

Made with [Cursor](https://cursor.com)