### PR TITLE
fix: leave headroom for rbf in multi_address_3

### DIFF
--- a/test/specs/multiaddress.e2e.ts
+++ b/test/specs/multiaddress.e2e.ts
@@ -178,7 +178,8 @@ describe('@multi_address - Multi address', () => {
     async () => {
       const addressTypes: addressTypePreference[] = ['p2pkh', 'p2sh-p2wpkh', 'p2wpkh', 'p2tr'];
       const satsPerAddressType = 10_000;
-      const sendAmountSats = 36_000;
+      // Keep enough change for RBF; 36k from 40k leaves ~1.7k change and boost coin-select fails
+      const sendAmountSats = 30_000;
       await switchAndFundEachAddressType({
         addressTypes,
         satsPerAddressType,


### PR DESCRIPTION
## Summary
- Fixes flaky `@multi_address_3` where `BoostSuccessToast` never appeared after RBF swipe.
- Sending 36k from 40k funded sats left ~1.7k taproot change; LDK RBF coin selection failed with insufficient funds (`Need at least: 37200sats`).
- Reduces send to 30k so enough change remains for fee bump while still testing multi-address-type send and RBF assertions.

## Context
CI on bitkit-android PR #978 (`multi_address_local` shard) failed all 3 attempts on `@multi_address_3` with `BoostSuccessToast` timeout. App logs show `Coin selection failed` / RBF boost failure, not a missing toast UI bug.

## Test plan
- [ ] `npm run e2e:android -- --spec ./test/specs/multiaddress.e2e.ts --mochaOpts.grep "@multi_address_3"`
- [ ] Confirm `@multi_address_1` and `@multi_address_4` still pass in the same spec

Made with [Cursor](https://cursor.com)