### PR TITLE
feat: add nodeId probe target support

### DIFF
--- a/test/helpers/probe.ts
+++ b/test/helpers/probe.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { getAppId } from './constants';
 
-export type ProbeTargetType = 'lightningAddress' | 'lnurlCallback';
+export type ProbeTargetType = 'lightningAddress' | 'lnurlCallback' | 'nodeId';
 
 export type ProbeTarget = {
   name: string;
@@ -14,11 +14,13 @@ export type ProbeTarget = {
   amountsMsat?: number[];
   address?: string;
   url?: string;
+  nodeId?: string;
 };
 
 export type ProbeResult = {
   targetName: string;
   targetType: ProbeTargetType;
+  probeMode: 'invoice' | 'keysend';
   amountMsat: number;
   amountSats: number;
   required: boolean;
@@ -28,6 +30,7 @@ export type ProbeResult = {
   success: boolean;
   durationMs: number;
   bolt11?: string;
+  nodeId?: string;
   rawProviderResult?: string;
   error?: string;
 };
@@ -129,9 +132,17 @@ export async function fetchBolt11ForProbe(
   return response.pr;
 }
 
-export function runProbeCommand(target: ProbeTarget, amountMsat: number, bolt11: string): string {
+export function probeModeForTargetType(type: ProbeTargetType): 'invoice' | 'keysend' {
+  return type === 'nodeId' ? 'keysend' : 'invoice';
+}
+
+export function runProbeInvoiceCommand(
+  target: ProbeTarget,
+  amountMsat: number,
+  bolt11: string
+): string {
   const amountSats = amountMsat / 1000;
-  const method = process.env.PROBE_CONTENT_METHOD ?? 'probeInvoice';
+  const method = process.env.PROBE_INVOICE_METHOD ?? 'probeInvoice';
   const timeoutSeconds =
     parsePositiveIntEnv('PROBE_TIMEOUT_SECONDS') ?? DEFAULT_PROBE_TIMEOUT_SECONDS;
   const payload = {
@@ -141,21 +152,29 @@ export function runProbeCommand(target: ProbeTarget, amountMsat: number, bolt11:
     amountSats,
     timeoutSeconds,
   };
-  const command = [
-    'content',
-    'call',
-    '--uri',
-    shellQuote(`content://${getAppId()}.devtools`),
-    '--method',
-    shellQuote(method),
-    '--arg',
-    shellQuote(JSON.stringify(payload)),
-  ].join(' ');
 
-  return execFileSync('adb', ['shell', command], {
-    encoding: 'utf8',
-    timeout: (timeoutSeconds + 10) * 1000,
-  });
+  return runDevToolsCommand(method, payload, timeoutSeconds);
+}
+
+export function runProbeNodeCommand(target: ProbeTarget, amountMsat: number): string {
+  const nodeId = target.nodeId;
+  if (!nodeId) {
+    throw new Error(`Probe target '${target.name}' is missing nodeId`);
+  }
+
+  const amountSats = amountMsat / 1000;
+  const method = process.env.PROBE_NODE_METHOD ?? 'probeNode';
+  const timeoutSeconds =
+    parsePositiveIntEnv('PROBE_TIMEOUT_SECONDS') ?? DEFAULT_PROBE_TIMEOUT_SECONDS;
+  const payload = {
+    targetName: target.name,
+    nodeId,
+    amountMsat,
+    amountSats,
+    timeoutSeconds,
+  };
+
+  return runDevToolsCommand(method, payload, timeoutSeconds);
 }
 
 export function parseProbeCommandSuccess(raw: string): boolean {
@@ -356,17 +375,18 @@ export function renderProbeReport(
     `Required failures: ${failedRequired.length}`,
     `Readiness at probe start: ${readiness ? summarizeProbeReadiness(readiness) : 'not captured'}`,
     '',
-    '| Target | Amount sats | Required | Invoice | Probe | Retries | Duration ms | Failure |',
-    '| --- | ---: | --- | --- | --- | ---: | ---: | --- |',
+    '| Target | Type | Amount sats | Required | Fetch | Probe | Retries | Duration ms | Failure |',
+    '| --- | --- | ---: | --- | --- | --- | ---: | ---: | --- |',
   ];
 
   for (const result of results) {
     lines.push(
       `| ${[
         result.targetName,
+        result.probeMode,
         result.amountSats.toString(),
         result.required ? 'yes' : 'no',
-        result.invoiceFetched ? 'ok' : 'failed',
+        formatFetchCell(result),
         result.success ? '✅' : '❌',
         result.retries.toString(),
         result.durationMs.toString(),
@@ -387,14 +407,21 @@ function parseProbeTarget(value: unknown): ProbeTarget {
   if (!target.name || typeof target.name !== 'string') {
     throw new Error('Each probe target must define a string name');
   }
-  if (target.type !== 'lightningAddress' && target.type !== 'lnurlCallback') {
-    throw new Error(`Probe target '${target.name}' has unsupported type '${target.type}'`);
+  if (
+    target.type !== 'lightningAddress' &&
+    target.type !== 'lnurlCallback' &&
+    target.type !== 'nodeId'
+  ) {
+    throw new Error(`Probe target '${target.name}' has unsupported type '${String(target.type)}'`);
   }
   if (target.type === 'lightningAddress' && !target.address) {
     throw new Error(`Probe target '${target.name}' must define address`);
   }
   if (target.type === 'lnurlCallback' && !target.url) {
     throw new Error(`Probe target '${target.name}' must define url`);
+  }
+  if (target.type === 'nodeId' && !target.nodeId) {
+    throw new Error(`Probe target '${target.name}' must define nodeId`);
   }
 
   return {
@@ -405,6 +432,7 @@ function parseProbeTarget(value: unknown): ProbeTarget {
     amountsMsat: target.amountsMsat,
     address: target.address,
     url: target.url,
+    nodeId: target.nodeId,
   };
 }
 
@@ -516,6 +544,33 @@ function formatFailureCell(error: string): string {
     return `\`${sanitized.replace(/`/g, "'")}\``;
   }
   return `\`${sanitized}\``;
+}
+
+function formatFetchCell(result: ProbeResult): string {
+  if (result.probeMode === 'keysend') return 'n/a';
+  return result.invoiceFetched ? 'ok' : 'failed';
+}
+
+function runDevToolsCommand(
+  method: string,
+  payload: Record<string, unknown>,
+  timeoutSeconds: number
+): string {
+  const command = [
+    'content',
+    'call',
+    '--uri',
+    shellQuote(`content://${getAppId()}.devtools`),
+    '--method',
+    shellQuote(method),
+    '--arg',
+    shellQuote(JSON.stringify(payload)),
+  ].join(' ');
+
+  return execFileSync('adb', ['shell', command], {
+    encoding: 'utf8',
+    timeout: (timeoutSeconds + 10) * 1000,
+  });
 }
 
 function shellQuote(value: string): string {

--- a/test/specs/mainnet/probe.e2e.ts
+++ b/test/specs/mainnet/probe.e2e.ts
@@ -5,8 +5,10 @@ import {
   fetchBolt11ForProbe,
   parseNonNegativeIntEnv,
   parseProbeCommandSuccess,
+  probeModeForTargetType,
   resolveProbeTargets,
-  runProbeCommand,
+  runProbeInvoiceCommand,
+  runProbeNodeCommand,
   summarizeProbeCommandFailure,
   waitForProbeReadiness,
   writeProbeArtifacts,
@@ -40,12 +42,13 @@ function resolveProbeRetryDelayMs(): number {
   return parseNonNegativeIntEnv('PROBE_RETRY_DELAY_MS') ?? DEFAULT_PROBE_RETRY_DELAY_MS;
 }
 
-async function runProbe(target: ProbeTarget, amountMsat: number): Promise<ProbeResult> {
+async function runInvoiceProbe(target: ProbeTarget, amountMsat: number): Promise<ProbeResult> {
   const startedAt = Date.now();
   const amountSats = amountMsat / 1000;
   const baseResult = {
     targetName: target.name,
     targetType: target.type,
+    probeMode: probeModeForTargetType(target.type),
     amountMsat,
     amountSats,
     required: target.required ?? true,
@@ -79,7 +82,7 @@ async function runProbe(target: ProbeTarget, amountMsat: number): Promise<ProbeR
           maxRetries + 1
         }...`
       );
-      const rawProviderResult = runProbeCommand(target, amountMsat, bolt11);
+      const rawProviderResult = runProbeInvoiceCommand(target, amountMsat, bolt11);
       lastRawProviderResult = rawProviderResult;
       const success = parseProbeCommandSuccess(rawProviderResult);
 
@@ -118,6 +121,80 @@ async function runProbe(target: ProbeTarget, amountMsat: number): Promise<ProbeR
   };
 }
 
+async function runNodeProbe(target: ProbeTarget, amountMsat: number): Promise<ProbeResult> {
+  const startedAt = Date.now();
+  const amountSats = amountMsat / 1000;
+  const nodeId = target.nodeId;
+  if (!nodeId) {
+    throw new Error(`Probe target '${target.name}' is missing nodeId`);
+  }
+
+  const baseResult = {
+    targetName: target.name,
+    targetType: target.type,
+    probeMode: probeModeForTargetType(target.type),
+    amountMsat,
+    amountSats,
+    required: target.required ?? true,
+    attempt: Number.parseInt(process.env.ATTEMPT ?? '1', 10),
+    nodeId,
+    invoiceFetched: false,
+  };
+
+  const maxRetries = resolveProbeRetries();
+  const retryDelayMs = resolveProbeRetryDelayMs();
+  let lastRawProviderResult = '';
+  let lastError = 'Probe command returned a failed result';
+
+  for (let retry = 0; retry <= maxRetries; retry++) {
+    try {
+      console.info(
+        `→ [Probe] Keysend probing '${target.name}' (${amountSats} sats), attempt ${retry + 1}/${
+          maxRetries + 1
+        }...`
+      );
+      const rawProviderResult = runProbeNodeCommand(target, amountMsat);
+      lastRawProviderResult = rawProviderResult;
+      const success = parseProbeCommandSuccess(rawProviderResult);
+
+      if (success) {
+        return {
+          ...baseResult,
+          retries: retry,
+          success: true,
+          durationMs: Date.now() - startedAt,
+          rawProviderResult,
+        };
+      }
+
+      lastError = summarizeProbeCommandFailure(rawProviderResult);
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+
+    if (retry < maxRetries && retryDelayMs > 0) {
+      console.info(`→ [Probe] Retrying '${target.name}' in ${retryDelayMs / 1000}s...`);
+      await sleep(retryDelayMs);
+    }
+  }
+
+  return {
+    ...baseResult,
+    retries: maxRetries,
+    success: false,
+    durationMs: Date.now() - startedAt,
+    rawProviderResult: lastRawProviderResult,
+    error: lastError,
+  };
+}
+
+async function runProbe(target: ProbeTarget, amountMsat: number): Promise<ProbeResult> {
+  if (target.type === 'nodeId') {
+    return runNodeProbe(target, amountMsat);
+  }
+  return runInvoiceProbe(target, amountMsat);
+}
+
 describe('@probe_mainnet - Lightning probe smoke', () => {
   let probeSeed: string;
   let targets: ProbeTarget[];
@@ -152,7 +229,7 @@ describe('@probe_mainnet - Lightning probe smoke', () => {
         const result = await runProbe(target, amountMsat);
         results.push(result);
         console.info(
-          `→ [Probe] ${result.targetName} ${result.amountSats} sats: ${
+          `→ [Probe] ${result.targetName} ${result.amountSats} sats (${result.probeMode}): ${
             result.success ? '✅ success' : `❌ failed (${result.error ?? 'unknown'})`
           }`
         );


### PR DESCRIPTION
## Summary

- Extend `ProbeTarget` with `nodeId` type for keysend-based mainnet probes
- Add `runProbeNodeCommand()` and branch probe spec on target type (invoice vs keysend)
- Include `probeMode` and `nodeId` in probe results; report table shows probe type and fetch status (`n/a` for keysend)

Depends on synonymdev/bitkit-android#1000 (`probeNode` devtools command).

Pairs with synonymdev/bitkit-nightly#22 (probe target config).

Closes synonymdev/bitkit-e2e-tests#176

## Test plan

- [ ] Build mainnet probe APK from android #1000 branch
- [ ] Run probe spec locally with `BACKEND=mainnet`, `APP_ID_ANDROID=to.bitkit`, `PROBE_SEED`, and targets JSON from nightly config
- [ ] Confirm invoice targets still pass (Cake, WoS, etc.)
- [ ] Confirm `nodeId` targets invoke `probeNode` and appear in `probe-report.md` with type `keysend`
- [ ] `workflow_dispatch` mainnet-probe with matching `e2e_tests_ref` and `probe_android_ref`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mainnet e2e probes can send real sats via keysend and depend on the Android `probeNode` devtools API; production app code is unchanged.
> 
> **Overview**
> Adds **`nodeId`** probe targets so mainnet smoke tests can **keysend** to a configured node instead of only LNURL/invoice flows.
> 
> Probe helpers gain **`probeMode`** (`invoice` | `keysend`), **`runProbeNodeCommand`** (devtools `probeNode`, overridable via `PROBE_NODE_METHOD`), and validation that `nodeId` targets include **`nodeId`**. Invoice probing is renamed to **`runProbeInvoiceCommand`** with env **`PROBE_INVOICE_METHOD`** (replacing `PROBE_CONTENT_METHOD`); shared adb **`runDevToolsCommand`** backs both paths.
> 
> The mainnet **`probe.e2e`** spec routes **`nodeId`** targets through **`runNodeProbe`** (no BOLT11 fetch) and keeps existing invoice behavior for other types. **`probe-report.md`** adds a Type column and shows Fetch as **`n/a`** for keysend runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be49b55ad58ee5f92928f9ad632e43681dd56e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->