### PR TITLE
feat: add probe order option

### DIFF
--- a/docs/mainnet-nightly.md
+++ b/docs/mainnet-nightly.md
@@ -35,6 +35,10 @@ To execute native E2E tests from an external orchestrator:
 - provide all secrets required by the selected tag(s)
 - pass grep/tag filters via CLI args, not by editing spec files
 
+## Suite-specific docs
+
+- `docs/mainnet-probe.md` — Lightning probe suite (`@probe_mainnet`): `PROBE_*` env var reference, artifacts, and local-run instructions.
+
 ## Adding or changing nightly coverage
 
 1. Add/update spec(s) and tags in `bitkit-e2e-tests`.

--- a/docs/mainnet-probe.md
+++ b/docs/mainnet-probe.md
@@ -1,0 +1,98 @@
+# Mainnet Lightning probe
+
+The `@probe_mainnet` suite (`test/specs/mainnet/probe.e2e.ts`) restores a funded mainnet wallet, waits for node readiness, then sends Lightning probes (invoice and keysend) to configured external targets and reports pass/fail per target and amount.
+
+It is orchestrated nightly by the private `bitkit-nightly` repo (`mainnet-probe.yml`), which owns schedules, secrets, and the probe target config. See `docs/mainnet-nightly.md` for the general contract between the repos.
+
+## Environment variables
+
+### Required
+
+| Variable | Description |
+| --- | --- |
+| `PROBE_SEED` | Mnemonic of a mainnet wallet with a usable Lightning channel and outbound liquidity. Keep secret. |
+| `PROBE_TARGETS_JSON` | JSON array of probe targets. Schema is documented in `bitkit-nightly/config/README.md` (canonical config: `bitkit-nightly/config/probe-targets.json`). |
+
+### Probe execution
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PROBE_ORDER` | `config` | Order of probes per target: `config` = amounts as listed in target config, `desc` = highest amount first (avoids small probes "warming up" scorer knowledge of the route), `random` = global shuffle of all target+amount pairs. |
+| `PROBE_RETRIES` | `2` | In-test retries per target+amount after a failed probe (total attempts = retries + 1). `0` = single attempt; useful to measure first-attempt success rate. |
+| `PROBE_RETRY_DELAY_MS` | `5000` | Delay between probe retries. |
+| `PROBE_DELAY_MS` | `10000` | Delay between consecutive probes (different target/amount). |
+| `PROBE_TIMEOUT_SECONDS` | `90` | Timeout for a single probe devtools command. |
+
+### Invoice fetching (LNURL / Lightning Address targets)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PROBE_FETCH_RETRIES` | `2` | Retries for LNURL metadata/invoice HTTP requests. |
+| `PROBE_FETCH_RETRY_DELAY_MS` | `1000` | Delay between fetch retries. |
+
+### Readiness gate
+
+Probing starts only after the node reports a healthy state (running, peers connected, usable channel, healthy sync, non-thin network graph).
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PROBE_READINESS_TIMEOUT_MS` | `180000` | Max wait for readiness before failing the test. |
+| `PROBE_READINESS_POLL_MS` | `5000` | Readiness poll interval. |
+| `PROBE_MIN_GRAPH_CHANNELS` | `10000` | Minimum network graph channel count required before probing. |
+
+### Devtools method overrides (rarely needed)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PROBE_INVOICE_METHOD` | `probeInvoice` | Devtools content-provider method for invoice probes. |
+| `PROBE_NODE_METHOD` | `probeNode` | Devtools method for keysend probes. |
+| `PROBE_READINESS_METHOD` | `probeReadiness` | Devtools method for the readiness check. |
+
+### Related (set by orchestration)
+
+| Variable | Description |
+| --- | --- |
+| `ATTEMPT` | Run attempt label (`1`, `2`, ...); selects the `artifacts/attempt-N/` output dir and is recorded in results. |
+| `LN_STABILIZE_DELAY_MS` | Extra settle delay after the mainnet wallet is restored (defaults to 45s on CI, 10s locally). |
+| `APPIUM_NEW_COMMAND_TIMEOUT` | Appium idle timeout; must exceed the longest single probe sequence (nightly uses `1800`). |
+
+## Artifacts
+
+Written to `artifacts/` (or `artifacts/attempt-N/` when `ATTEMPT` is set):
+
+- `probe-results.json` — per-probe results (target, amount, success, retries, duration, error)
+- `probe-report.md` — markdown summary table (also appended to `GITHUB_STEP_SUMMARY` on CI)
+- `probe-readiness.json` — node readiness snapshot at probe start
+
+## Running locally
+
+1. Set up env vars:
+
+```bash
+export PROBE_SEED="your wallet seed here..."
+export PROBE_TARGETS_JSON="$(jq -c . ../bitkit-nightly/config/probe-targets.json)"
+```
+
+2. Build a mainnet APK (requires `bitkit-android` checked out next to this repo):
+
+```bash
+BACKEND=mainnet ./scripts/build-android-apk.sh
+```
+
+3. Run the suite:
+
+```bash
+PLATFORM=android \
+BACKEND=mainnet \
+APP_ID_ANDROID=to.bitkit \
+AUT_FILENAME=bitkit_e2e_mainnet.apk \
+LN_STABILIZE_DELAY_MS=25000 \
+APPIUM_NEW_COMMAND_TIMEOUT=1200 \
+./ci_run_android.sh --spec ./test/specs/mainnet/probe.e2e.ts --mochaOpts.grep "@probe_mainnet"
+```
+
+Notes:
+
+- The wallet derived from `PROBE_SEED` must already have an open, usable channel with outbound liquidity covering the largest configured probe amount.
+- Probes do not move funds; the wallet balance is unchanged by a run.
+- For scorer experiments, prefer `PROBE_ORDER=desc PROBE_RETRIES=0` to measure cold first-attempt success rate per amount.

--- a/test/helpers/probe.ts
+++ b/test/helpers/probe.ts
@@ -88,6 +88,41 @@ export function resolveProbeTargets(): ProbeTarget[] {
   return parsed.map(parseProbeTarget);
 }
 
+export type ProbeOrder = 'desc' | 'random' | 'config';
+
+export type ProbeQueueEntry = { target: ProbeTarget; amountMsat: number };
+
+export function resolveProbeOrder(): ProbeOrder {
+  const raw = process.env.PROBE_ORDER?.toLowerCase();
+  if (!raw) return 'config';
+  if (raw === 'desc' || raw === 'random' || raw === 'config') return raw;
+  throw new Error(`Invalid PROBE_ORDER value: ${raw} (expected desc, random or config)`);
+}
+
+export function buildProbeQueue(targets: ProbeTarget[], order: ProbeOrder): ProbeQueueEntry[] {
+  const queue = targets.flatMap((target) => {
+    const amounts = expandProbeTargetAmounts(target);
+    if (order === 'desc') {
+      amounts.sort((a, b) => b - a);
+    }
+    return amounts.map((amountMsat) => ({ target, amountMsat }));
+  });
+
+  if (order === 'random') {
+    shuffleInPlace(queue);
+  }
+
+  return queue;
+}
+
+function shuffleInPlace<T>(items: T[]): T[] {
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+  return items;
+}
+
 export function expandProbeTargetAmounts(target: ProbeTarget): number[] {
   const amounts = target.amountsMsat ?? (target.amountMsat ? [target.amountMsat] : []);
   if (amounts.length === 0) {
@@ -373,6 +408,7 @@ export function renderProbeReport(
     '# Lightning Probe Report',
     '',
     `Required failures: ${failedRequired.length}`,
+    `Probe order: ${resolveProbeOrder()}`,
     `Readiness at probe start: ${readiness ? summarizeProbeReadiness(readiness) : 'not captured'}`,
     '',
     '| Target | Type | Amount sats | Required | Fetch | Probe | Retries | Duration ms | Failure |',

--- a/test/helpers/probe.ts
+++ b/test/helpers/probe.ts
@@ -408,7 +408,7 @@ export function renderProbeReport(
     '# Lightning Probe Report',
     '',
     `Required failures: ${failedRequired.length}`,
-    `Probe order: ${resolveProbeOrder()}`,
+    `Probe order: ${probeOrderForReport()}`,
     `Readiness at probe start: ${readiness ? summarizeProbeReadiness(readiness) : 'not captured'}`,
     '',
     '| Target | Type | Amount sats | Required | Fetch | Probe | Retries | Duration ms | Failure |',
@@ -432,6 +432,16 @@ export function renderProbeReport(
   }
 
   return `${lines.join('\n')}\n`;
+}
+
+// Report rendering runs from the spec's finally block, so it must never throw
+// and mask the original test failure (e.g. an invalid PROBE_ORDER value).
+function probeOrderForReport(): string {
+  try {
+    return resolveProbeOrder();
+  } catch {
+    return `invalid (${process.env.PROBE_ORDER})`;
+  }
 }
 
 function parseProbeTarget(value: unknown): ProbeTarget {

--- a/test/specs/mainnet/probe.e2e.ts
+++ b/test/specs/mainnet/probe.e2e.ts
@@ -1,11 +1,12 @@
 import { restoreWallet, sleep } from '../../helpers/actions';
 import { waitForMainnetWalletReady } from '../../helpers/mainnet';
 import {
-  expandProbeTargetAmounts,
+  buildProbeQueue,
   fetchBolt11ForProbe,
   parseNonNegativeIntEnv,
   parseProbeCommandSuccess,
   probeModeForTargetType,
+  resolveProbeOrder,
   resolveProbeTargets,
   runProbeInvoiceCommand,
   runProbeNodeCommand,
@@ -218,12 +219,16 @@ describe('@probe_mainnet - Lightning probe smoke', () => {
       await waitForMainnetWalletReady({ logPrefix: 'Probe' });
       readiness = await waitForProbeReadiness({ logPrefix: 'Probe' });
 
-      const probes = targets.flatMap((target) =>
-        expandProbeTargetAmounts(target).map((amountMsat) => ({ target, amountMsat }))
-      );
+      const probeOrder = resolveProbeOrder();
+      const probes = buildProbeQueue(targets, probeOrder);
       const probeDelayMs = resolveProbeDelayMs();
       const probeRetries = resolveProbeRetries();
       console.info(`→ [Probe] Probe retries configured: ${probeRetries}`);
+      console.info(
+        `→ [Probe] Probe order '${probeOrder}': ${probes
+          .map((it) => `${it.target.name}:${it.amountMsat / 1000}`)
+          .join(', ')}`
+      );
 
       for (const [index, { target, amountMsat }] of probes.entries()) {
         const result = await runProbe(target, amountMsat);


### PR DESCRIPTION
## Summary

- Add `PROBE_ORDER` env var to the `@probe_mainnet` suite controlling probe execution order: `config` (default, as listed in target config), `desc` (highest amount first), `random` (global shuffle).
- Rationale: ascending amounts "warm up" the local scorer's route knowledge before higher-amount probes run, inflating their success rate vs. a cold real-user send ([Slack discussion](https://synonymworkspace.slack.com/archives/C07BJ7DNPCG/p1781103399339429?thread_ts=1781096598.706949&cid=C07BJ7DNPCG)). The nightly orchestrator will set `desc`.
- Log the resolved probe queue at start and include the order in `probe-report.md`.
- Document all `PROBE_*` and related env vars, artifacts, and local-run instructions in `docs/mainnet-probe.md`.

Companion PR in `bitkit-nightly` wires `probe_retries` and `probe_order` dispatch inputs (defaults `2` / `desc`).

## Test plan

- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] Dispatch `mainnet-probe.yml` with `e2e_tests_ref=probe-order-option` and verify probe order in logs/report

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E probe helpers, the mainnet probe spec, and documentation; no app or payment-path production code is modified.
> 
> **Overview**
> Adds **`PROBE_ORDER`** to the `@probe_mainnet` suite so probe runs can follow config order (default), **highest amount first** (`desc`), or a **global shuffle** (`random`), mainly so small probes do not warm up route scoring before larger amounts.
> 
> The spec now builds the run queue via `resolveProbeOrder` / `buildProbeQueue`, logs the resolved sequence at start, and records the order in **`probe-report.md`** (with report rendering that will not throw on invalid `PROBE_ORDER`).
> 
> New **`docs/mainnet-probe.md`** documents `PROBE_*` env vars, artifacts, and local runs; **`docs/mainnet-nightly.md`** links to it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb281df238336904193f57a86567b045acea948d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->